### PR TITLE
Add comment for listToSequenceLinkConverter argument

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data.Doublets.Sequences/issues/7
-Your prepared branch: issue-7-15346c40
-Your prepared working directory: /tmp/gh-issue-solver-1757815963042
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data.Doublets.Sequences/issues/7
+Your prepared branch: issue-7-15346c40
+Your prepared working directory: /tmp/gh-issue-solver-1757815963042
+
+Proceed.

--- a/csharp/Platform.Data.Doublets.Sequences/Unicode/StringToUnicodeSequenceConverter.cs
+++ b/csharp/Platform.Data.Doublets.Sequences/Unicode/StringToUnicodeSequenceConverter.cs
@@ -65,7 +65,7 @@ namespace Platform.Data.Doublets.Sequences.Unicode
         /// <para></para>
         /// </param>
         /// <param name="listToSequenceLinkConverter">
-        /// <para>A list to sequence link converter.</para>
+        /// <para>A list to sequence link converter. Possible values (inherited from LinksListToSequenceConverterBase): OptimalVariantConverter, BalancedVariantConverter, CompressingConverter.</para>
         /// <para></para>
         /// </param>
         /// <param name="unicodeSequenceMarker">
@@ -95,7 +95,7 @@ namespace Platform.Data.Doublets.Sequences.Unicode
         /// <para></para>
         /// </param>
         /// <param name="listToSequenceLinkConverter">
-        /// <para>A list to sequence link converter.</para>
+        /// <para>A list to sequence link converter. Possible values (inherited from LinksListToSequenceConverterBase): OptimalVariantConverter, BalancedVariantConverter, CompressingConverter.</para>
         /// <para></para>
         /// </param>
         /// <param name="unicodeSequenceMarker">
@@ -121,7 +121,7 @@ namespace Platform.Data.Doublets.Sequences.Unicode
         /// <para></para>
         /// </param>
         /// <param name="listToSequenceLinkConverter">
-        /// <para>A list to sequence link converter.</para>
+        /// <para>A list to sequence link converter. Possible values (inherited from LinksListToSequenceConverterBase): OptimalVariantConverter, BalancedVariantConverter, CompressingConverter.</para>
         /// <para></para>
         /// </param>
         /// <param name="unicodeSequenceMarker">
@@ -147,7 +147,7 @@ namespace Platform.Data.Doublets.Sequences.Unicode
         /// <para></para>
         /// </param>
         /// <param name="listToSequenceLinkConverter">
-        /// <para>A list to sequence link converter.</para>
+        /// <para>A list to sequence link converter. Possible values (inherited from LinksListToSequenceConverterBase): OptimalVariantConverter, BalancedVariantConverter, CompressingConverter.</para>
         /// <para></para>
         /// </param>
         /// <param name="unicodeSequenceMarker">


### PR DESCRIPTION
## Summary
Added documentation comment for the `listToSequenceLinkConverter` parameter in `StringToUnicodeSequenceConverter.cs` to clarify possible values that can be used.

## Changes Made
- Updated XML documentation comments for the `listToSequenceLinkConverter` parameter in all constructor overloads
- Added information about possible values inherited from `LinksListToSequenceConverterBase`:
  - `OptimalVariantConverter`
  - `BalancedVariantConverter`
  - `CompressingConverter`

## Test Plan
- [x] Built the solution successfully with `dotnet build` - no compilation errors
- [x] Verified all constructor overloads in `StringToUnicodeSequenceConverter` have updated documentation
- [x] Confirmed the listed converters actually inherit from `LinksListToSequenceConverterBase`

Fixes #7

🤖 Generated with [Claude Code](https://claude.ai/code)